### PR TITLE
Version 4.2.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/gettext-feedstock/pr5/43eba1c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/gettext-feedstock/pr5/43eba1c

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ function mkdir_touch()
     touch $dir/.mkdir
 }
 
-$PYTHON setup.py install --single-version-externally-managed --record record.txt
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation
 
 mkdir_touch $PREFIX/etc/supervisord/conf.d
 mkdir_touch $PREFIX/etc/supervisord/startup

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,8 +19,6 @@ function mkdir_touch()
 }
 
 $PYTHON -m pip install . -vv --no-deps --no-build-isolation
-# Don't install the test suite.
-rm -r $SP_DIR/supervisor/tests
 
 mkdir_touch $PREFIX/etc/supervisord/conf.d
 mkdir_touch $PREFIX/etc/supervisord/startup

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ function mkdir_touch()
     touch $dir/.mkdir
 }
 
-$PYTHON -m pip install . -vv --no-deps --no-build-isolation
+$PYTHON -m pip install --single-version-externally-managed --record record.txt --no-deps --no-build-isolation
 
 mkdir_touch $PREFIX/etc/supervisord/conf.d
 mkdir_touch $PREFIX/etc/supervisord/startup

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ function mkdir_touch()
     touch $dir/.mkdir
 }
 
-$PYTHON -m pip install . -vv --no-deps --no-build-isolation
+$PYTHON setup.py install --single-version-externally-managed --record record.txt
 
 mkdir_touch $PREFIX/etc/supervisord/conf.d
 mkdir_touch $PREFIX/etc/supervisord/startup

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,6 +19,8 @@ function mkdir_touch()
 }
 
 $PYTHON -m pip install . -vv --no-deps --no-build-isolation
+# Don't install the test suite.
+rm -r $SP_DIR/supervisor/tests
 
 mkdir_touch $PREFIX/etc/supervisord/conf.d
 mkdir_touch $PREFIX/etc/supervisord/startup

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ function mkdir_touch()
     touch $dir/.mkdir
 }
 
-$PYTHON -m pip install --single-version-externally-managed --record record.txt --no-deps --no-build-isolation
+$PYTHON setup.py install --single-version-externally-managed --record record.txt
 
 mkdir_touch $PREFIX/etc/supervisord/conf.d
 mkdir_touch $PREFIX/etc/supervisord/startup

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ build:
 
 requirements:
   host:
-    - gettext
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "supervisor" %}
-{% set version = "4.2.2" %}
+{% set version = "4.2.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5b2b8882ec8a3c3733cce6965cc098b6d80b417f21229ab90b18fe551d619f90
+  sha256: 34761bae1a23c58192281a5115fb07fbf22c9b0133c08166beffc70fed3ebc12
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ test:
   source_files:
     - supervisor/tests/
   commands:
-    - cp -r supervisor/tests $SP_DIR/supervisor
     - pip check
     - py.test supervisor/tests/
     - supervisord -h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   host:
+    - gettext
     - pip
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,11 +30,13 @@ requirements:
 
 test:
   requires:
+    - pip
     - pytest >=2.5.2
     - mock >=0.5.0
   source_files:
     - supervisor/tests/
   commands:
+    - pip check
     - py.test supervisor/tests/
     - supervisord -h
     - supervisorctl -h
@@ -44,7 +46,7 @@ test:
 
 about:
   home: http://supervisord.org/
-  license: BSD-derived AND PSF AND Other
+  license: BSD-3-Clause-Modification AND BSD-3-Clause AND PSF-2.0
   license_file: LICENSES.txt
   license_family: BSD
   summary: A Process Control System
@@ -52,7 +54,6 @@ about:
     Supervisor is a client/server system that allows its users to monitor and
     control a number of processes on UNIX-like operating systems.
   doc_url: http://supervisord.org/
-  doc_source_url: https://github.com/Supervisor/supervisor
   dev_url: https://github.com/Supervisor/supervisor
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
   source_files:
     - supervisor/tests/
   commands:
+    - cp -r supervisor/tests $SP_DIR/supervisor
     - pip check
     - py.test supervisor/tests/
     - supervisord -h


### PR DESCRIPTION
supervisor 4.2.5

**Destination channel:** defaults

### Links

- [PKG-3809](https://anaconda.atlassian.net/browse/PKG-3809) 
- [Upstream repository](https://github.com/Supervisor/supervisor/tree/4.2.5)
- [Upstream changelog/diff](http://supervisord.org/changes.html)

### Explanation of changes:

- Update version and `sha256`
- Linter fixes


[PKG-3809]: https://anaconda.atlassian.net/browse/PKG-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ